### PR TITLE
fix warnings

### DIFF
--- a/lodepng.c
+++ b/lodepng.c
@@ -29,11 +29,6 @@ Rename this file to lodepng.cpp to use it for C++, or to lodepng.c to use it for
 */
 
 #include "lodepng.h"
-#if LV_LVGL_H_INCLUDE_SIMPLE
-#include <lvgl.h>
-#else
-#include <lvgl/lvgl.h>
-#endif
 
 #ifdef LODEPNG_COMPILE_DISK
 #include <limits.h> /* LONG_MAX */
@@ -617,7 +612,7 @@ static unsigned readBits(LodePNGBitReader* reader, size_t nbits) {
 }
 
 /* Public for testing only. steps and result must have numsteps values. */
-unsigned lode_png_test_bitreader(const unsigned char* data, size_t size,
+static unsigned lode_png_test_bitreader(const unsigned char* data, size_t size,
                                  size_t numsteps, const size_t* steps, unsigned* result) {
   size_t i;
   LodePNGBitReader reader;
@@ -3635,7 +3630,7 @@ function, do not use to process all pixels of an image. Alpha channel not suppor
 this is for bKGD, supporting alpha may prevent it from finding a color in the palette, from the
 specification it looks like bKGD should ignore the alpha values of the palette since it can use
 any palette index but doesn't have an alpha channel. Idem with ignoring color key. */
-unsigned lodepng_convert_rgb(
+static unsigned lodepng_convert_rgb(
     unsigned* r_out, unsigned* g_out, unsigned* b_out,
     unsigned r_in, unsigned g_in, unsigned b_in,
     const LodePNGColorMode* mode_out, const LodePNGColorMode* mode_in) {

--- a/lodepng.h
+++ b/lodepng.h
@@ -33,10 +33,10 @@ freely, subject to the following restrictions:
 #endif
 
 #if LV_PNG_USE_LV_FILESYSTEM
-#ifdef LV_LVGL_H_INCLUDE_SIMPLE
-#include <lvgl.h>
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
 #else
-#include <lvgl/lvgl.h>
+#include "lvgl/lvgl.h"
 #endif
 #endif /* LV_PNG_USE_LV_FILESYSTEM */
 

--- a/lv_png.c
+++ b/lv_png.c
@@ -6,10 +6,10 @@
 /*********************
  *      INCLUDES
  *********************/
-#ifdef LV_LVGL_H_INCLUDE_SIMPLE
-#include <lvgl.h>
+#if defined(LV_LVGL_H_INCLUDE_SIMPLE)
+#include "lvgl.h"
 #else
-#include <lvgl/lvgl.h>
+#include "lvgl/lvgl.h"
 #endif
 
 #include "lv_png.h"
@@ -84,7 +84,7 @@ static lv_res_t decoder_info(struct _lv_img_decoder_t * decoder, const void * sr
 #if LV_PNG_USE_LV_FILESYSTEM
              lv_fs_file_t f;
              lv_fs_res_t res = lv_fs_open(&f, fn, LV_FS_MODE_RD);
-             if(res != LV_FS_RES_OK) return -1;
+             if(res != LV_FS_RES_OK) return LV_RES_INV;
              lv_fs_seek(&f, 16, LV_FS_SEEK_SET);
              uint32_t rn;
              lv_fs_read(&f, &size, 8, &rn);


### PR DESCRIPTION
```
CC /home/vifextech/workpath/misc/lv_sim_eclipse_sdl/lv_lib_png/lv_png.c
/home/vifextech/workpath/misc/lv_sim_eclipse_sdl/lv_lib_png/lodepng.c:32:5: warning: "LV_LVGL_H_INCLUDE_SIMPLE" is not defined, evaluates to 0 [-Wundef]
   32 | #if LV_LVGL_H_INCLUDE_SIMPLE
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
/home/vifextech/workpath/misc/lv_sim_eclipse_sdl/lv_lib_png/lodepng.c:620:10: warning: no previous prototype for ‘lode_png_test_bitreader’ [-Wmissing-prototypes]
  620 | unsigned lode_png_test_bitreader(const unsigned char* data, size_t size,
      |          ^~~~~~~~~~~~~~~~~~~~~~~
/home/vifextech/workpath/misc/lv_sim_eclipse_sdl/lv_lib_png/lodepng.c:3638:10: warning: no previous prototype for ‘lodepng_convert_rgb’ [-Wmissing-prototypes]
 3638 | unsigned lodepng_convert_rgb(
      |          ^~~~~~~~~~~~~~~~~~~
CC /home/vifextech/workpath/misc/lv_sim_eclipse_sdl/lv_lib_png/lodepng.c
```