### PR TITLE
lodepng.c: make mem. mgmt. syms externally visible

### DIFF
--- a/lodepng.c
+++ b/lodepng.c
@@ -71,7 +71,7 @@ lodepng source code. Don't forget to remove "static" if you copypaste them
 from here.*/
 
 #ifdef LODEPNG_COMPILE_ALLOCATORS
-static void* lodepng_malloc(size_t size) {
+void* lodepng_malloc(size_t size) {
 #ifdef LODEPNG_MAX_ALLOC
   if(size > LODEPNG_MAX_ALLOC) return 0;
 #endif
@@ -79,14 +79,14 @@ static void* lodepng_malloc(size_t size) {
 }
 
 /* NOTE: when realloc returns NULL, it leaves the original memory untouched */
-static void* lodepng_realloc(void* ptr, size_t new_size) {
+void* lodepng_realloc(void* ptr, size_t new_size) {
 #ifdef LODEPNG_MAX_ALLOC
   if(new_size > LODEPNG_MAX_ALLOC) return 0;
 #endif
   return realloc(ptr, new_size);
 }
 
-static void lodepng_free(void* ptr) {
+void lodepng_free(void* ptr) {
   free(ptr);
 }
 #else /*LODEPNG_COMPILE_ALLOCATORS*/


### PR DESCRIPTION
Another compilation unit (`lv_png.c`) tries to be consistent and references
the memory management function `lodepng_free`. As this method is declared private (i.e. `static`)
to the defining unit (i.e. `lodepng.c`), the symbol is not linkable with other compilation units.

By making the symbols externally visible (i.e. non-`static`), they can be linked.