### PR TITLE
feat(cmake-build): Option to allow building shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,16 @@ project(lv_lib_png
   HOMEPAGE_URL https://github.com/lvgl/lv_lib_png
   )
 
+# Option to build as shared library (as opposed to static), default: OFF
+option(BUILD_SHARED_LIBS "Build shared as library (as opposed to static)" OFF)
+
 file(GLOB_RECURSE SOURCES *.c)
-add_library(${CMAKE_PROJECT_NAME} STATIC ${SOURCES})
+
+if (BUILD_SHARED_LIBS)
+  add_library(${CMAKE_PROJECT_NAME} SHARED ${SOURCES})
+else()
+  add_library(${CMAKE_PROJECT_NAME} STATIC ${SOURCES})
+endif()
 
 if("${LIB_INSTALL_DIR}" STREQUAL "")
   set(LIB_INSTALL_DIR "lib")
@@ -21,10 +29,14 @@ file(GLOB LV_DRIVERS_PUBLIC_HEADERS
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
   OUTPUT_NAME ${CMAKE_PROJECT_NAME}
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
   PUBLIC_HEADER "${LV_DRIVERS_PUBLIC_HEADERS}"
 )
 
 install(TARGETS ${CMAKE_PROJECT_NAME}
   ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
+  LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
+  RUNTIME DESTINATION "${LIB_INSTALL_DIR}"
   PUBLIC_HEADER DESTINATION "${INC_INSTALL_DIR}"
 )


### PR DESCRIPTION
Add option in CMake build to specify that shared libraries should be created (as opposed to static). This is an exclusive option (not enabled by default).